### PR TITLE
Upgrade gitlab-ci-runner version to 12.10.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,13 +3,13 @@ FROM ubuntu:16.04
 MAINTAINER TobiLG <tobilg@gmail.com>
 
 # Download dumb-init
-ADD https://github.com/Yelp/dumb-init/releases/download/v1.0.2/dumb-init_1.0.2_amd64 /usr/bin/dumb-init
+ADD https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_amd64 /usr/bin/dumb-init
 
 ENV DIND_COMMIT 3b5fac462d21ca164b3778647420016315289034
 
-ENV GITLAB_RUNNER_VERSION=10.0.2
+ENV GITLAB_RUNNER_VERSION="12.10.3"
 
-ENV DOCKER_ENGINE_VERSION=1.13.1-0~ubuntu-xenial
+ENV DOCKER_CE_VERSION="5:19.03.13~3-0~ubuntu-xenial"
 
 # Install components and do the preparations
 # 1. Install needed packages
@@ -29,10 +29,10 @@ RUN apt-get update -y && \
     chmod -R 700 /etc/gitlab-runner && \
     curl -sSL https://raw.githubusercontent.com/tobilg/mesosdns-resolver/master/mesosdns-resolver.sh -o /usr/local/bin/mesosdns-resolver && \
     chmod +x /usr/local/bin/mesosdns-resolver && \
-    apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D && \
-    apt-add-repository 'deb https://apt.dockerproject.org/repo ubuntu-xenial main' && \
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \
+    add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" && \
     apt-get update && \
-    apt-get install -y docker-engine=${DOCKER_ENGINE_VERSION} && \
+    apt-get install -y docker-ce=${DOCKER_CE_VERSION} docker-ce-cli=${DOCKER_CE_VERSION} containerd.io && \
     curl -sSL https://raw.githubusercontent.com/docker/docker/${DIND_COMMIT}/hack/dind -o /usr/local/bin/dind && \
     chmod a+x /usr/local/bin/dind && \
     apt-get clean && \

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ An example for a shell runner. This enables the build of Docker images.
   "container": {
     "type": "DOCKER",
     "docker": {
-      "image": "tobilg/gitlab-ci-runner-marathon:v10.0.2",
+      "image": "tobilg/gitlab-ci-runner-marathon:v12.10.3",
       "network": "HOST",
       "forcePullImage": true,
       "privileged": true
@@ -82,7 +82,7 @@ Here's an example for a Docker runner, which enables builds *inside* Docker cont
   "container": {
     "type": "DOCKER",
     "docker": {
-      "image": "tobilg/gitlab-ci-runner-marathon:v10.0.2",
+      "image": "tobilg/gitlab-ci-runner-marathon:v12.10.3",
       "network": "HOST",
       "forcePullImage": true,
       "privileged": true

--- a/register_and_run.sh
+++ b/register_and_run.sh
@@ -137,4 +137,4 @@ trap _getTerminationSignal TERM
 gitlab-runner register
 
 # Start the runner
-gitlab-runner run --working-directory=${RUNNER_WORK_DIR} --metrics-server $HOST:$PORT0
+gitlab-runner run --working-directory=${RUNNER_WORK_DIR} --listen-address $HOST:$PORT0


### PR DESCRIPTION
- Upgrade runner to `12.10.3`
- Upgrade docker-ce to `19.03`
- Upgrade dumb-init to `1.2.2`
- Updated readme to new image version
- Replaced deprecated gitlab-runner run params `--metrics-server` with `--listen-address`

Fix #8

Tested successfully.